### PR TITLE
instrumentation hooks, borrow timeout, rename options/variables

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,9 @@
-import Pool, { Options, Deferred, Borrowed } from "./"
+import Pool, {
+  Options,
+  Deferred,
+  Borrowed,
+  RequestCancellationReason,
+} from "./"
 
 describe("utility test cases", () => {
   test("deferred has reject/resolve immediately available", async () => {
@@ -26,6 +31,15 @@ describe("utility test cases", () => {
 })
 
 describe("basic test case", () => {
+  type HookCounts = {
+    onCreate: number
+    onDispose: number
+    onBorrow: number
+    onReturn: number
+    onRequestEnqueued: number
+    onRequestDequeued: number
+    onRequestCancelled: RequestCancellationReason[]
+  }
   const options: Options = {
     minResources: 0,
     maxResources: 10,
@@ -36,6 +50,15 @@ describe("basic test case", () => {
   const disposed: jest.Mock<any, any>[] = []
 
   class TestPool extends Pool<jest.Mock> {
+    public hookCounts: HookCounts = {
+      onCreate: 0,
+      onDispose: 0,
+      onBorrow: 0,
+      onReturn: 0,
+      onRequestEnqueued: 0,
+      onRequestDequeued: 0,
+      onRequestCancelled: [],
+    }
     create(): Promise<jest.Mock> {
       createCount++
       return Promise.resolve(jest.fn())
@@ -46,6 +69,15 @@ describe("basic test case", () => {
       disposed.push(rsc)
       return Promise.resolve()
     }
+
+    // instrumentation
+    onCreate = () => this.hookCounts.onCreate++
+    onDispose = () => this.hookCounts.onDispose++
+    onBorrow = () => this.hookCounts.onBorrow++
+    onRequestEnqueued = () => this.hookCounts.onRequestEnqueued++
+    onRequestDequeued = () => this.hookCounts.onRequestDequeued++
+    onRequestCancelled = (reason: RequestCancellationReason) =>
+      this.hookCounts.onRequestCancelled.push(reason)
   }
 
   afterEach(() => {
@@ -70,6 +102,16 @@ describe("basic test case", () => {
     expect(rsc2).toBeCalledTimes(1)
     // verify is same resource
     expect(rsc2).toBe(rsc)
+
+    // verify hooks
+    expect(pool.hookCounts).toEqual(
+      createHookCounts({
+        onCreate: 1,
+        onBorrow: 2,
+        onRequestEnqueued: 1,
+        onRequestDequeued: 1,
+      })
+    )
   })
 
   test("borrow returns different resources", async () => {
@@ -81,10 +123,20 @@ describe("basic test case", () => {
     expect(rsc1).toBeTruthy()
     expect(rsc2).toBeTruthy()
     expect(rsc1).not.toBe(rsc2)
+
+    // verify hooks
+    expect(pool.hookCounts).toEqual(
+      createHookCounts({
+        onCreate: 2,
+        onBorrow: 2,
+        onRequestEnqueued: 2,
+        onRequestDequeued: 2,
+      })
+    )
   })
 
   test("borrow cannot exceed cap", async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const pool = new TestPool({ minResources: 0, maxResources: 2 })
 
@@ -100,26 +152,42 @@ describe("basic test case", () => {
       setTimeout(() => {
         release1()
         release2()
-        setTimeout(() => pool.destroy().then(() => resolve()), 10)
+        setTimeout(() => {
+          expect(pool.hookCounts).toEqual(
+            createHookCounts({
+              onCreate: 2,
+              onBorrow: 3,
+              onRequestEnqueued: 3,
+              onRequestDequeued: 3,
+            })
+          )
+          pool.destroy().then(() => resolve())
+        }, 10)
       }, 10)
     })
   })
 
   test("pool with minimum set allocates resources", async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const pool = new TestPool({ minResources: 5, maxResources: 10 })
 
     return new Promise<void>((resolve) => {
       setTimeout(() => {
         expect(createCount).toEqual(5)
+        expect(pool.hookCounts).toEqual(
+          createHookCounts({
+            onCreate: 5,
+          })
+        )
+
         pool.destroy().then(() => resolve())
       }, 10)
     })
   })
 
   test("pool rejects in-flight borrows on destroy", async () => {
-    expect.assertions(10)
+    expect.assertions(11)
     const pool = new TestPool({ minResources: 0, maxResources: 10 })
 
     const borrows: Promise<Borrowed<jest.Mock>>[] = []
@@ -129,17 +197,29 @@ describe("basic test case", () => {
 
     pool.destroy().then()
 
-    borrows.forEach((borrow) => {
+    const promises = borrows.map((borrow) =>
       borrow
         .then(() => {
           throw new Error("fail: borrow should not succeed")
         })
         .catch((e) => expect(e).toBeTruthy())
-    })
+    )
+
+    await Promise.all(promises).then(() =>
+      expect(pool.hookCounts).toEqual(
+        createHookCounts({
+          onCreate: 1,
+          onRequestEnqueued: 10,
+          onRequestCancelled: new Array(10).fill(
+            RequestCancellationReason.Destroyed
+          ),
+        })
+      )
+    )
   })
 
   test("pool ends all resources on destroy", async () => {
-    expect.assertions(2)
+    expect.assertions(3)
     const pool = new TestPool({ minResources: 5, maxResources: 10 })
 
     // borrow a resource to fully sync the pool
@@ -150,6 +230,28 @@ describe("basic test case", () => {
     await pool.destroy().then(() => {
       expect(createCount).toBe(5)
       expect(disposeCount).toBe(5)
+      expect(pool.hookCounts).toEqual(
+        createHookCounts({
+          onBorrow: 1,
+          onCreate: 5,
+          onDispose: 5,
+          onRequestEnqueued: 1,
+          onRequestDequeued: 1,
+        })
+      )
     })
   })
+
+  function createHookCounts(countsPartial: Partial<HookCounts>): HookCounts {
+    return {
+      onCreate: 0,
+      onDispose: 0,
+      onBorrow: 0,
+      onReturn: 0,
+      onRequestEnqueued: 0,
+      onRequestDequeued: 0,
+      onRequestCancelled: [],
+      ...countsPartial,
+    }
+  }
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,7 @@ abstract class Pool<T> {
     }
 
     this.onRequestDequeued?.()
+    this.onBorrow?.()
     // lend the resource
     const borrow: Borrowed<T> = [rsc, () => this.returnResource(rsc)]
     return deferred.resolve(borrow)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,12 @@ import { Deferred } from "./utils"
 export interface Options {
   minResources: number
   maxResources: number
+  resourceMaxAge?: number
 
-  maxRequests?: number
-
-  acquireTimeout?: number
-  disposeTimeout?: number
-  borrowTimeout?: number
-  idleTimeout?: number
+  maxOutstandingBorrows?: number
+  defaultBorrowTimeout?: number
 
   syncInterval?: number
-  resourceMaxAge?: number
 }
 
 export interface BorrowOptions {
@@ -44,12 +40,51 @@ export class TimeoutError extends Error {
   }
 }
 
+export class MaxOutstandingBorrowsError extends Error {
+  public constructor(msg = "max outstanding borrows exceeded") {
+    super(msg)
+    Object.setPrototypeOf(this, MaxOutstandingBorrowsError.prototype)
+    this.name = "MaxOutstandingBorrowsError"
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MaxOutstandingBorrowsError)
+    }
+    this.message = msg
+  }
+}
+
+export class PoolDestroyedError extends Error {
+  public constructor(msg = "pool is destroyed") {
+    super(msg)
+    Object.setPrototypeOf(this, PoolDestroyedError.prototype)
+    this.name = "PoolDestroyedError"
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PoolDestroyedError)
+    }
+    this.message = msg
+  }
+}
+
+export class UnknownResourceError extends Error {
+  public constructor(msg = "resource is unknown to this pool") {
+    super(msg)
+    Object.setPrototypeOf(this, UnknownResourceError.prototype)
+    this.name = "UnknownResourceError"
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UnknownResourceError)
+    }
+    this.message = msg
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface Pool<T> {
   onCreate?: () => void
   onDispose?: () => void
   onBorrow?: () => void
-  onReturn?: () => void
+  onRelease?: () => void
   onRequestEnqueued?: () => void
   onRequestDequeued?: () => void
   onRequestCancelled?: (reason: RequestCancellationReason) => void
@@ -57,11 +92,11 @@ interface Pool<T> {
 
 abstract class Pool<T> {
   protected options: Options
-  private ending = false
+  private isDestroying = false
 
-  private known: Map<T, ObjectInfo> = new Map()
-  private available: Array<T> = []
-  private queue: Array<Deferred<Borrowed<T>>> = []
+  private knownResources: Map<T, ObjectInfo> = new Map()
+  private availableResources: Array<T> = []
+  private outstandingBorrows: Array<Deferred<Borrowed<T>>> = []
 
   private syncTimeout?: NodeJS.Timer
   private syncing?: Promise<void>
@@ -96,11 +131,11 @@ abstract class Pool<T> {
   }
 
   public borrow = async (options?: BorrowOptions): Promise<Borrowed<T>> => {
-    if (this.ending) {
-      throw new Error("pool is ending")
+    if (this.isDestroying) {
+      throw new PoolDestroyedError()
     }
 
-    const rsc = this.available.shift()
+    const rsc = this.availableResources.shift()
     if (rsc && this.resourceIsExpired(rsc)) {
       this.removeResource(rsc)
     } else if (rsc) {
@@ -111,7 +146,7 @@ abstract class Pool<T> {
     }
 
     const future = new Deferred<Borrowed<T>>()
-    this.queue.push(future)
+    this.outstandingBorrows.push(future)
     this.onRequestEnqueued?.()
 
     // sync pool, which may add a resource for this request; or it may reject it
@@ -122,18 +157,18 @@ abstract class Pool<T> {
     }
 
     // handle resource acquisition timeout, if any
-    const timeout = options?.timeout ?? this.options.borrowTimeout
+    const timeout = options?.timeout ?? this.options.defaultBorrowTimeout
     if (timeout) {
       let tid: NodeJS.Timer
       return Promise.race([
         future.promise.finally(() => clearTimeout(tid)),
         new Promise<Borrowed<T>>((resolve, reject) => {
           setTimeout(() => {
-            const idx = this.queue.indexOf(future)
+            const idx = this.outstandingBorrows.indexOf(future)
             if (idx !== undefined) {
               this.onRequestCancelled?.(RequestCancellationReason.Timeout)
               this.onRequestDequeued?.()
-              this.queue.splice(idx, 1)
+              this.outstandingBorrows.splice(idx, 1)
             }
             reject(new TimeoutError())
           }, timeout)
@@ -141,11 +176,12 @@ abstract class Pool<T> {
       ])
     }
 
+    // no timeout to handle, just return the promise
     return future.promise
   }
 
-  public get outstandingRequests(): number {
-    return this.queue.length
+  public get outstandingBorrowsCount(): number {
+    return this.outstandingBorrows.length
   }
 
   public remove = async (rsc: T): Promise<void> => {
@@ -153,7 +189,7 @@ abstract class Pool<T> {
   }
 
   public destroy = async (): Promise<void> => {
-    this.ending = true
+    this.isDestroying = true
 
     // stop pool sync, if it's doing so on interval
     if (this.syncTimeout) {
@@ -161,22 +197,24 @@ abstract class Pool<T> {
     }
 
     // reject all queued requests
-    this.queue.splice(0, this.queue.length).forEach((p) => {
-      this.onRequestCancelled?.(RequestCancellationReason.Destroyed)
-      this.onRequestDequeued?.()
-      p.reject(new Error("pool is ending"))
-    })
+    this.outstandingBorrows
+      .splice(0, this.outstandingBorrows.length)
+      .forEach((p) => {
+        this.onRequestCancelled?.(RequestCancellationReason.Destroyed)
+        this.onRequestDequeued?.()
+        p.reject(new PoolDestroyedError())
+      })
 
     // drain available pool
-    const promises = this.available
-      .splice(0, this.available.length)
+    const promises = this.availableResources
+      .splice(0, this.availableResources.length)
       .map(this.removeResource)
 
     return Promise.all(promises).then()
   }
 
   private addResource = async (rsc: T): Promise<void> => {
-    if (this.known.get(rsc)) {
+    if (this.knownResources.get(rsc)) {
       throw new Error(
         "addResource called on a resource that already exists in the pool"
       )
@@ -184,18 +222,18 @@ abstract class Pool<T> {
     const info: ObjectInfo = {
       created: Date.now(),
     }
-    this.known.set(rsc, info)
+    this.knownResources.set(rsc, info)
 
     return this.maybeLendResource(rsc)
   }
 
   private maybeLendResource = async (rsc: T): Promise<void> => {
     // see if there's a waiting borrower that can use the resource
-    const deferred = this.queue.shift()
+    const deferred = this.outstandingBorrows.shift()
 
     // if not, put it back in the pool
     if (!deferred) {
-      this.available.push(rsc)
+      this.availableResources.push(rsc)
       return
     }
 
@@ -207,11 +245,11 @@ abstract class Pool<T> {
   }
 
   private returnResource = async (rsc: T): Promise<void> => {
-    const info = this.known.get(rsc)
+    const info = this.knownResources.get(rsc)
     if (!info) {
-      throw new Error("return resource called for unknown object")
+      throw new UnknownResourceError()
     }
-    this.onReturn?.()
+    this.onRelease?.()
 
     const { resourceMaxAge } = this.options
 
@@ -224,10 +262,10 @@ abstract class Pool<T> {
   }
 
   private removeResource = (rsc: T): Promise<void> => {
-    this.known.delete(rsc)
-    const idx = this.available.indexOf(rsc)
+    this.knownResources.delete(rsc)
+    const idx = this.availableResources.indexOf(rsc)
     if (idx > -1) {
-      this.available.slice(idx, 1)
+      this.availableResources.slice(idx, 1)
     }
 
     return this._dispose(rsc)
@@ -235,9 +273,9 @@ abstract class Pool<T> {
 
   private resourceIsExpired = (rsc: T): boolean => {
     const { resourceMaxAge = Infinity } = this.options
-    const info = this.known.get(rsc)
+    const info = this.knownResources.get(rsc)
     if (!info) {
-      throw new Error("object is unknown to this pool")
+      throw new UnknownResourceError()
     }
 
     return Date.now() - info.created > resourceMaxAge
@@ -245,10 +283,14 @@ abstract class Pool<T> {
 
   private sync = async (): Promise<void> => {
     const promises: Promise<unknown>[] = []
-    const { maxResources, minResources, maxRequests = Infinity } = this.options
+    const {
+      maxResources,
+      minResources,
+      maxOutstandingBorrows: maxRequests = Infinity,
+    } = this.options
 
     // expire out of date resources
-    this.available = this.available.slice().filter((rsc) => {
+    this.availableResources = this.availableResources.slice().filter((rsc) => {
       if (!this.resourceIsExpired(rsc)) {
         promises.push(this.removeResource(rsc))
         return
@@ -258,8 +300,8 @@ abstract class Pool<T> {
     })
 
     // grow resource pool if allowed/necessary
-    const currentSize = this.known.size
-    const deficit = this.queue.length
+    const currentSize = this.knownResources.size
+    const deficit = this.outstandingBorrows.length
     const requestedSize = Math.max(
       minResources,
       Math.min(currentSize + deficit, maxResources)
@@ -271,15 +313,15 @@ abstract class Pool<T> {
     }
 
     // reject any queued requests over the queue limit
-    if (this.queue.length > maxRequests) {
-      this.queue
-        .splice(maxRequests, this.queue.length - maxRequests)
+    if (this.outstandingBorrows.length > maxRequests) {
+      this.outstandingBorrows
+        .splice(maxRequests, this.outstandingBorrows.length - maxRequests)
         .forEach((future) => {
           this.onRequestCancelled?.(
             RequestCancellationReason.MaxQueuedRequestsExceeded
           )
           this.onRequestDequeued?.()
-          future.reject(new Error("queue length exceeded"))
+          future.reject(new MaxOutstandingBorrowsError())
         })
     }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,26 @@
+import { Deferred } from "./utils"
+
+describe("utility test cases", () => {
+  test("deferred has reject/resolve immediately available", async () => {
+    const deferred = new Deferred<number>()
+    expect(deferred.resolve).toBeTruthy()
+    expect(deferred.reject).toBeTruthy()
+    deferred.resolve(3)
+    expect(await deferred.promise).toBe(3)
+  })
+  test("deferred promise resolves", async () => {
+    const deferred = new Deferred<number>()
+    deferred.resolve(3)
+    expect(await deferred.promise).toBe(3)
+  })
+  test("deferred promise reject", async () => {
+    const deferred = new Deferred<number>()
+    deferred.reject(new Error("dang"))
+    try {
+      await deferred.promise
+      fail("should not resolve")
+    } catch (e) {
+      expect(e).toBeTruthy()
+    }
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+export class Deferred<T> {
+  public promise: Promise<T>
+  public resolve!: (value: T) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public reject!: (reason?: any) => void
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = resolve
+      this.reject = reject
+    })
+  }
+}


### PR DESCRIPTION
* adds instrumentation hooks so that it's possible to add metrics to your pool class
* implements a borrow timeout, both as a default for all borrows or as an override to an individual borrow
* various renames to better describe both internal and external features